### PR TITLE
Add Telegram Stars payment option

### DIFF
--- a/tgbot/database/db_helper.py
+++ b/tgbot/database/db_helper.py
@@ -126,7 +126,7 @@ def create_dbx():
 
         ############################################################
         # Создание таблицы с хранением - Данных платежных систем
-        if len(con.execute("PRAGMA table_info(storage_payments)").fetchall()) == 4:
+        if len(con.execute("PRAGMA table_info(storage_payments)").fetchall()) == 5:
             print("DB was found(3/8)")
         else:
             con.execute(
@@ -135,7 +135,8 @@ def create_dbx():
                         cryptobot_token TEXT,
                         yoomoney_token TEXT,
                         status_cryptobot TEXT,
-                        status_yoomoney TEXT
+                        status_yoomoney TEXT,
+                        status_stars TEXT
                     )
                 """)
             )
@@ -146,13 +147,15 @@ def create_dbx():
                         cryptobot_token,
                         yoomoney_token,
                         status_cryptobot,
-                        status_yoomoney
-                    ) 
-                    VALUES (?, ?, ?, ?)
+                        status_yoomoney,
+                        status_stars
+                    )
+                    VALUES (?, ?, ?, ?, ?)
                 """),
                 [
                     'None',
                     'None',
+                    'False',
                     'False',
                     'False',
                 ]

--- a/tgbot/database/db_payments.py
+++ b/tgbot/database/db_payments.py
@@ -13,6 +13,7 @@ class PaymentsModel(BaseModel):
     yoomoney_token: str  # Юмани токен
     status_cryptobot: str  # Статус работы криптобота
     status_yoomoney: str  # Статус работы юмани
+    status_stars: str = 'False'  # Статус пополнения звездочками
 
 
 # Работа с платежными системами

--- a/tgbot/keyboards/inline_admin.py
+++ b/tgbot/keyboards/inline_admin.py
@@ -123,6 +123,24 @@ def payment_cryptobot_finl() -> InlineKeyboardMarkup:
     return keyboard.as_markup()
 
 
+# Управление - Telegram Stars
+def payment_stars_finl() -> InlineKeyboardMarkup:
+    keyboard = InlineKeyboardBuilder()
+
+    get_payments = Paymentsx.get()
+
+    if getattr(get_payments, 'status_stars', 'False') == "True":
+        status_kb = ikb("Статус: Включено ✅", data="payment_stars_status:False")
+    else:
+        status_kb = ikb("Статус: Выключено ❌", data="payment_stars_status:True")
+
+    keyboard.row(
+        status_kb,
+    )
+
+    return keyboard.as_markup()
+
+
 ################################################################################
 ################################## НАСТРОЙКИ ###################################
 # Основные настройки

--- a/tgbot/keyboards/inline_user.py
+++ b/tgbot/keyboards/inline_user.py
@@ -47,6 +47,8 @@ def refill_method_finl() -> InlineKeyboardMarkup:
         keyboard.row(ikb("🔷 Криптовалюта", data="user_refill_method:Cryptobot"))
     if get_payments.status_yoomoney == "True":
         keyboard.row(ikb("💳 Карта", data="user_refill_method:Yoomoney"))
+    if getattr(get_payments, 'status_stars', 'False') == "True":
+        keyboard.row(ikb("🌟 Stars", data="user_refill_method:Stars"))
 
     keyboard.row(ikb("🔙 Вернуться", data="user_profile"))
 
@@ -76,6 +78,8 @@ def refill_method_buy_finl() -> InlineKeyboardMarkup:
         keyboard.row(ikb("🔷 Криптовалюта", data="user_refill_method:Cryptobot"))
     if get_payments.status_yoomoney == "True":
         keyboard.row(ikb("💳 Карта", data="user_refill_method:Yoomoney"))
+    if getattr(get_payments, 'status_stars', 'False') == "True":
+        keyboard.row(ikb("🌟 Stars", data="user_refill_method:Stars"))
 
     keyboard.row(ikb("❌ Закрыть", data="close_this"))
 

--- a/tgbot/keyboards/reply_main.py
+++ b/tgbot/keyboards/reply_main.py
@@ -31,7 +31,7 @@ def payments_frep() -> ReplyKeyboardMarkup:
     keyboard = ReplyKeyboardBuilder()
 
     keyboard.row(
-        rkb("🔷 CryptoBot"), rkb("🔮 ЮMoney"),
+        rkb("🔷 CryptoBot"), rkb("🔮 ЮMoney"), rkb("🌟 Telegram Stars"),
     ).row(
         rkb("🔙 Главное меню"),
     )

--- a/tgbot/routers/admin/admin_payment.py
+++ b/tgbot/routers/admin/admin_payment.py
@@ -4,7 +4,7 @@ from aiogram.filters import StateFilter
 from aiogram.types import CallbackQuery, Message
 
 from tgbot.database import Paymentsx
-from tgbot.keyboards.inline_admin import payment_yoomoney_finl, close_finl, payment_cryptobot_finl
+from tgbot.keyboards.inline_admin import payment_yoomoney_finl, close_finl, payment_cryptobot_finl, payment_stars_finl
 from tgbot.services.api_cryptobot import CryptobotAPI
 from tgbot.services.api_yoomoney import YoomoneyAPI
 from tgbot.utils.const_functions import ded
@@ -32,6 +32,17 @@ async def payment_yoomoney_open(message: Message, bot: Bot, state: FSM, arSessio
     await message.answer(
         "<b>🔮 Управление - ЮMoney</b>",
         reply_markup=payment_yoomoney_finl(),
+    )
+
+
+# Управление - Telegram Stars
+@router.message(F.text == "🌟 Telegram Stars")
+async def payment_stars_open(message: Message, bot: Bot, state: FSM, arSession: ARS):
+    await state.clear()
+
+    await message.answer(
+        "<b>🌟 Управление - Telegram Stars</b>",
+        reply_markup=payment_stars_finl(),
     )
 
 
@@ -98,6 +109,19 @@ async def payment_cryptobot_status(call: CallbackQuery, bot: Bot, state: FSM, ar
     await call.message.edit_text(
         "<b>🔷 Управление - CryptoBot</b>",
         reply_markup=payment_cryptobot_finl(),
+    )
+
+
+# Выключатель - Telegram Stars
+@router.callback_query(F.data.startswith("payment_stars_status:"))
+async def payment_stars_status(call: CallbackQuery, bot: Bot, state: FSM, arSession: ARS):
+    get_status = call.data.split(":")[1]
+
+    Paymentsx.update(status_stars=get_status)
+
+    await call.message.edit_text(
+        "<b>🌟 Управление - Telegram Stars</b>",
+        reply_markup=payment_stars_finl(),
     )
 
 

--- a/tgbot/routers/main_start.py
+++ b/tgbot/routers/main_start.py
@@ -28,6 +28,7 @@ prohibit_refill = [
     'user_refill_method',
     'Pay:Cryptobot',
     'Pay:Yoomoney',
+    'Pay:Stars',
     'Pay:',
 ]
 

--- a/tgbot/routers/user/user_products.py
+++ b/tgbot/routers/user/user_products.py
@@ -94,7 +94,11 @@ async def user_buy_open(call: CallbackQuery, bot: Bot, state: FSM, arSession: AR
 
     # Проверка, имеется ли на балансе пользователя достаточно средств
     if int(get_user.user_balance) < int(get_position.position_price):
-        if get_payments.status_cryptobot == "True" or get_payments.status_yoomoney == "True":
+        if (
+            get_payments.status_cryptobot == "True"
+            or get_payments.status_yoomoney == "True"
+            or getattr(get_payments, 'status_stars', 'False') == "True"
+        ):
             await call.message.answer(
                 "<b>❗ На вашем счёте недостаточно средств</b>\n"
                 "💰 Выберите способ пополнения баланса",


### PR DESCRIPTION
## Summary
- support Telegram Stars deposits with automatic crediting
- allow admins to toggle Stars payments
- show Stars as a payment choice in user and admin interfaces

## Testing
- `python -m py_compile tgbot/database/db_helper.py tgbot/database/db_payments.py tgbot/keyboards/inline_admin.py tgbot/keyboards/inline_user.py tgbot/keyboards/reply_main.py tgbot/routers/admin/admin_payment.py tgbot/routers/main_start.py tgbot/routers/user/user_products.py tgbot/routers/user/user_transactions.py`
- `python -m py_compile tgbot/database/db_payments.py tgbot/routers/user/user_transactions.py`

------
https://chatgpt.com/codex/tasks/task_e_689899ac534c8324a58d2d3fa57cd1ba